### PR TITLE
fwk-detect: Build for SOD devices

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,1 +1,2 @@
 #include $(all-subdir-makefiles)
+include $(call all-makefiles-under,vendor/qcom/opensource/core-utils/fwk-detect)

--- a/fwk-detect/Android.bp
+++ b/fwk-detect/Android.bp
@@ -1,3 +1,6 @@
+soong_namespace{
+}
+
 cc_library_shared {
     name: "libqti_vndfwk_detect",
     srcs: ["vndfwk-detect.c"],

--- a/fwk-detect/Android.mk
+++ b/fwk-detect/Android.mk
@@ -1,0 +1,4 @@
+ifeq ($(BOARD_USES_QCOM_HARDWARE),)
+PRODUCT_SOONG_NAMESPACES += \
+    vendor/qcom/opensource/core-utils/fwk-detect
+endif


### PR DESCRIPTION
* This is basically a follow up of https://gerrit.pixelexperience.org/c/hardware_qcom-caf_common/+/2222

Signed-off-by: Henrique Pereira <hlcpereira@pixelexperience.org>