### PR TITLE
Namespace SODP core-utils repo

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,0 +1,2 @@
+soong_namespace {
+}

--- a/fwk-detect/Android.bp
+++ b/fwk-detect/Android.bp
@@ -2,7 +2,7 @@ cc_library_shared {
     name: "libqti_vndfwk_detect",
     srcs: ["vndfwk-detect.c"],
     shared_libs: ["libcutils"],
-    vendor: true,
+    vendor_available: true,
     export_include_dirs: ["."],
 
     compile_multilib: "both",
@@ -16,7 +16,7 @@ cc_test {
     name: "vndfwk-test",
     srcs: ["vndfwk-test.c"],
     shared_libs: ["libqti_vndfwk_detect"],
-    vendor: true,
+    vendor_available: true,
 
     cflags: [
         "-Wall",
@@ -41,7 +41,7 @@ cc_library_shared {
         "jni_headers",
     ],
 
-    vendor: true,
+    vendor_available: true,
     compile_multilib: "both",
 
     cflags: [


### PR DESCRIPTION
For compatibility with PE we are namespacing our specific copy, to allow duplicate (BluePrint) modules to coexist.

The namespace can be accessed in regular Makefiles and the device repos with:
PRODUCT_SOONG_NAMESPACES += \
    vendor/qcom/opensource/core-utils