### PR TITLE
[R] fwk-detect: Drop libnativehelper includes

### DIFF
--- a/fwk-detect/Android.bp
+++ b/fwk-detect/Android.bp
@@ -34,7 +34,6 @@ cc_library_shared {
         "liblog",
     ],
     include_dirs: [
-        "libnativehelper/include/nativehelper",
         ".",
     ],
     header_libs: [

--- a/fwk-detect/jni/com_qualcomm_qti_VndFwkDetect.cpp
+++ b/fwk-detect/jni/com_qualcomm_qti_VndFwkDetect.cpp
@@ -32,11 +32,14 @@
 #include "vndfwk-detect.h"
 
 #include "jni.h"
-#include "JNIHelp.h"
 #include <dlfcn.h>
 #include <string.h>
 #include <android/log.h>
 #include <utils/Log.h>
+
+#ifndef NELEM
+#define NELEM(x) ((int) (sizeof(x) / sizeof((x)[0])))
+#endif
 
 #define VNDFWK_DETECT_LIB "libqti_vndfwk_detect.so"
 


### PR DESCRIPTION
Modules are not supposed to include headers from outside their module directories directly, either rely on header-only libraries or rely on linked modules re-exporting them.

Since only one macro is used from `JNIHelp.h`, just copy it here.